### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+# Maven generated files
+Back-End/SparkServer/csc648_team2_backend.iml
+
 # IDE files
 .DS_Store
 .idea
+.vs


### PR DESCRIPTION
Just adding the .vs IDE folder to gitignore, as well as the .iml file generated by Maven. The .iml file _can_ be kept in version control, but is not necessary since anyone opening the project has to download maven dependencies anyway, and the file is then generated.