### PR TITLE
Update pt endpoint to fetch by email

### DIFF
--- a/Back-End/SparkServer/SparkServerReadMe.md
+++ b/Back-End/SparkServer/SparkServerReadMe.md
@@ -6,11 +6,11 @@ To see an example user payload, query http://localhost:8080/api/example/user
 ---
 
 ####PT
-To add a PT to the database, the api endpoint to use is `/api/pt/register` with the query parameters `email, f_name, l_name, company`. This should be a POST request.
+To add a PT to the database, the api endpoint to use is `/api/pt/register` with the query parameters `email, password, f_name, l_name, company`. This should be a POST request.
 
 To retrieve all users who are PT's, use the endpoint `/api/pt/all`. This should be a GET request.
 
-To retrieve a specific PT, use the endpoint `/api/pt/id` with the query parameter `pt_id`. This should be a GET request.
+To retrieve a specific PT, use the endpoint `/api/pt/email` with the query parameter `email`. This should be a GET request.
 
 To retrieve the patients belonging to a specific PT, use the endpoint `api/pt/patients` with the query parameter `pt_id`. This should be a GET request.
 
@@ -18,13 +18,14 @@ To retrieve the patients belonging to a specific PT, use the endpoint `api/pt/pa
 ```
 [
     {
-        "pt_id": 2,
-        "user": 12,
-        "user_id": 12,
-        "email": "bruce.lee@gmail.com",
-        "f_name": "bruce",
-        "l_name": "lee",
-        "company": "awesome fighters inc"
+        "pt_id": 1,
+        "user": 251,
+        "user_id": 251,
+        "email": "jsmith@gmail.com",
+        "f_name": "John",
+        "l_name": "Smith",
+        "company": "HealQuik",
+        "secret": "passwordEncryption"
     }
 ]
 ```
@@ -32,7 +33,7 @@ To retrieve the patients belonging to a specific PT, use the endpoint `api/pt/pa
 ---
 
 ####Patient
-To add a Patient to the database, the api endpoint to use is `/api/patient/register` with the query parameters `email, f_name, l_name, company`. This should be a POST request.
+To add a Patient to the database, the api endpoint to use is `/api/patient/register` with the query parameters `email, password, f_name, l_name, company`. This should be a POST request.
 
 Patients can be updated to add a PT link by using `api/patient/update-pt` with query parameters `patient_id, pt, prospective_pt`. This should be a PUT request.
 
@@ -43,14 +44,15 @@ Patients can be retrieved by calling a GET request on `api/patient/all` for all 
 [
     {
         "patient_id": 1,
-        "user": 14,
-        "pt": 2,
-        "prospective_pt": 2,
-        "user_id": 14,
-        "email": "test@mail.com",
-        "f_name": "jane",
-        "l_name": "doe",
-        "company": "the NY co"
+        "user": 497,
+        "pt": 1,
+        "prospective_pt": 0,
+        "user_id": 497,
+        "email": "jsmith@hotmail.com",
+        "f_name": "John",
+        "l_name": "Smith",
+        "company": "Lazzy",
+        "secret": "passwordEncryption"
     }
 ]
 ```

--- a/Back-End/SparkServer/endpoints.txt
+++ b/Back-End/SparkServer/endpoints.txt
@@ -1,11 +1,11 @@
-GET     api/pt/id                      params: pt_id
+GET     api/pt/email                   params: email
 GET     api/pt/all
 GET     api/pt/patients                params: pt_id
-POST    api/pt/register                params: email, f_name, l_name, company
+POST    api/pt/register                params: email, password, f_name, l_name, company
 
 GET     api/patient/id                 params: patient_id
 GET     api/patient/all
-POST    api/patient/register           params: email, f_name, l_name, company
+POST    api/patient/register           params: email, password, f_name, l_name, company
 PUT     api/patient/update-pt          params: patient_id, pt, prospective_pt
 
 GET     api/patient/entry/id           params: entry_id

--- a/Back-End/SparkServer/src/main/server/PT/PT.java
+++ b/Back-End/SparkServer/src/main/server/PT/PT.java
@@ -14,6 +14,8 @@ public class PT extends User {
 
   public PT(Integer pt_id){this.pt_id=pt_id;}
 
+  public PT(String email){this.setEmail(email);}
+
 	public void createPT() throws Exception {
 		String userQuery = "INSERT INTO user(user_id, email, password, f_name, l_name, company) VALUES(NULL, ?, ?, ?, ?, ?);";
 		String ptQuery = "INSERT INTO pt(pt_id, user) VALUES(NULL, LAST_INSERT_ID())";
@@ -42,14 +44,14 @@ public class PT extends User {
   
 	public PT getPT() throws Exception {
 		String ptQuery = "SELECT * FROM user u JOIN pt p " +
-				"ON u.user_id = p.user WHERE p.pt_id = " + this.pt_id;
+				"ON u.user_id = p.user WHERE u.email = ?";
 
 		try (Connection con = DriverManager.getConnection(
 				Server.databasePath,
 				Server.databaseUsername,
 				Server.databasePassword);
 			 PreparedStatement pst = con.prepareStatement(ptQuery)) {
-			pst.executeQuery(ptQuery);
+			pst.setString(1, this.getEmail());
 
 			ResultSet rs = pst.executeQuery();
 			if (rs.next()) {
@@ -62,9 +64,11 @@ public class PT extends User {
 				setF_name(rs.getString("f_name"));
 				setL_name(rs.getString("l_name"));
 				setCompany(rs.getString("company"));
+			} else {
+				throw new SQLException("A user with that email doesn't exist.");
 			}
 		} catch (SQLException ex) {
-			throw new Exception("Error getting pt with id " + this.pt_id + ": " + ex.toString());
+			throw new SQLException("Error getting pt with email " + this.getEmail() + ": " + ex.toString());
 		}
 
 		return this;

--- a/Back-End/SparkServer/src/main/server/PT/PTUtil.java
+++ b/Back-End/SparkServer/src/main/server/PT/PTUtil.java
@@ -17,7 +17,7 @@ public class PTUtil {
 	public static String selectSpecific(Request request, Response response) {
 		String toReturn = "";
 		try {
-			PT pt = new PT(Integer.parseInt(request.queryMap().get("pt_id").value()));
+			PT pt = new PT(request.queryMap().get("email").value());
 			Gson gson = new Gson();
 			toReturn = gson.toJson(pt.getPT());
 

--- a/Back-End/SparkServer/src/main/server/Server.java
+++ b/Back-End/SparkServer/src/main/server/Server.java
@@ -51,7 +51,7 @@ public class Server {
 			before("/*", (q, a) -> System.out.println("Received api call"));
 
 			path("/pt", () -> {
-				get("/id", PTUtil::selectSpecific);
+				get("/email", PTUtil::selectSpecific);
 				get("/all", (request, response) -> PTUtil.selectAll(response));
 				get("/patients", PTUtil::selectPatients);
 


### PR DESCRIPTION
I updated the `api/pt/id` endpoint to instead be `api/pt/email` with query parameter `email` to fetch specific PT's. This allows the frontend to fetch a PT at their sign-in, by making the request with the given email, thus getting the PT's data without needing the ID.

Also updated the relevant sections of documentation.