### PR TITLE
Add comments to entries

### DIFF
--- a/Back-End/SparkServer/src/main/server/Entry/Entry.java
+++ b/Back-End/SparkServer/src/main/server/Entry/Entry.java
@@ -14,6 +14,7 @@ public class Entry {
   private String entry;
   private Timestamp created_on;
   private Integer patient;
+  private String comment;
 
   /**
    * Entry constructor: Cannot be NULL because this constructor implies creating a matching object
@@ -82,12 +83,33 @@ public class Entry {
         setEntry(rs.getString("entry"));
         setCreated_on(rs.getTimestamp("created_on"));
         setPatient(rs.getInt("patient"));
+        setComment(rs.getString("comment"));
       }
     } catch (SQLException ex) {
       throw new Exception("Error getting entry with id " + this.entry_id + ": " + ex.toString());
     }
 
     return this;
+  }
+
+  /**
+   * Update the existing entry with a new comment, given the existing entry object has been initialized with ID.
+   * @param comment The string comment
+   * @throws Exception Throw a SQL exception so that frontend has context for the error.
+   */
+  public void updateEntry(String comment) throws Exception {
+    String query = "UPDATE entry SET comment = '" + comment + "' WHERE entry_id = " + this.entry_id;
+
+    try (Connection con =
+                 DriverManager.getConnection(
+                         Server.databasePath, Server.databaseUsername, Server.databasePassword);
+         PreparedStatement pst = con.prepareStatement(query)) {
+      pst.executeUpdate(query);
+      System.out.println("Entry updated");
+    } catch (SQLException ex) {
+      throw new Exception(
+              "Error updating Entry with id " + this.entry_id + ": " + ex.toString());
+    }
   }
 
   /**
@@ -124,5 +146,13 @@ public class Entry {
 
   public void setPatient(Integer patient) {
     this.patient = patient;
+  }
+
+  public String getComment() {
+    return comment;
+  }
+
+  public void setComment(String comment) {
+    this.comment = comment;
   }
 }

--- a/Back-End/SparkServer/src/main/server/Entry/EntryTest.java
+++ b/Back-End/SparkServer/src/main/server/Entry/EntryTest.java
@@ -50,4 +50,10 @@ class EntryTest {
     entry.setPatient(1000);
     assertEquals(1000, entry.getPatient());
   }
+
+  @Test
+  void setComment() {
+    entry.setComment("test");
+    assertEquals("test", entry.getComment());
+  }
 }

--- a/Back-End/SparkServer/src/main/server/Entry/EntryUtil.java
+++ b/Back-End/SparkServer/src/main/server/Entry/EntryUtil.java
@@ -68,6 +68,7 @@ public class EntryUtil {
         Entry entry = new Entry(rs.getString("entry"), rs.getInt("patient"));
         entry.setEntry_id(rs.getInt("entry_id"));
         entry.setCreated_on(rs.getTimestamp("created_on"));
+        entry.setComment(rs.getString("comment"));
         list.add(entry);
       }
       Gson gson = new Gson();
@@ -100,6 +101,28 @@ public class EntryUtil {
               request.queryMap().get("entry").value(),
               Integer.parseInt(request.queryMap().get("patient_id").value()));
       entry.createEntry();
+      return 200;
+    } catch (SQLException sqlEx) {
+      System.err.println(sqlEx.toString());
+      return 500;
+    } catch (Exception ex) {
+      System.err.println(ex.toString());
+      return 400;
+    }
+  }
+
+  /**
+   * Add a comment to an existing entry, given it's ID.
+   * @param request Required parameters: entry_id, comment
+   * @return The status code value
+   */
+  public static Integer updateComment(Request request) {
+    try {
+      Entry entry = new Entry(Integer.parseInt(request.queryMap().get("entry_id").value()));
+      entry
+        .getDBEntry()
+        .updateEntry(request.queryMap().get("comment").value());
+
       return 200;
     } catch (SQLException sqlEx) {
       System.err.println(sqlEx.toString());

--- a/Back-End/SparkServer/src/main/server/Entry/EntryUtilTest.java
+++ b/Back-End/SparkServer/src/main/server/Entry/EntryUtilTest.java
@@ -76,4 +76,19 @@ class EntryUtilTest {
 
     assertEquals(200, response.getStatus());
   }
+
+  @Test
+  void testAddComment() {
+    when(request.getParameter("entry_id")).thenReturn("1");
+    when(request.getParameter("comment")).thenReturn("Test comment.");
+    when(response.getStatus()).thenReturn(200);
+
+    Entry entry = new Entry(Integer.parseInt(request.getParameter("entry_id")));
+    entry.setComment(request.getParameter("comment"));
+
+    assertEquals(1, entry.getEntry_id());
+    assertEquals("Test comment.", entry.getComment());
+
+    assertEquals(200, response.getStatus());
+  }
 }

--- a/Back-End/SparkServer/src/main/server/Server.java
+++ b/Back-End/SparkServer/src/main/server/Server.java
@@ -157,6 +157,13 @@ public class Server {
                             response.status(EntryUtil.registerEntry(request));
                             return response.status();
                           });
+                      // Requires entry_id and comment
+                      put(
+						  "/comment",
+						  (request, response) -> {
+							  response.status(EntryUtil.updateComment(request));
+							  return response.status();
+						  });
                     });
 
                 path(


### PR DESCRIPTION
I added the comment column to the entry table, and updated our queries accordingly. Also, added the updateComment entry point under `api/patient/entry/comment` with `entry_id` and `comment` as params. Updated the unit testing accordingly.